### PR TITLE
Fix for the latest version of the AWS API/Boto3

### DIFF
--- a/bin/ecs-run-cmd
+++ b/bin/ecs-run-cmd
@@ -5,7 +5,7 @@ from retrying import retry
 import argh
 import boto3
 import sys
-from pprint import pprint
+
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
@@ -168,8 +168,6 @@ def run_task(**kwargs):
         get_override,
         containers
     ))
-
-    
 
     result = client.run_task(
         cluster=kwargs['ECS_CLUSTER'],

--- a/bin/ecs-run-cmd
+++ b/bin/ecs-run-cmd
@@ -1,17 +1,17 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
+
 from retrying import retry
 import argh
 import boto3
 import sys
-
+from pprint import pprint
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
-def filter(d): return {k: v for k, v in d.iteritems() if v is not None}
+def filter(d): return {k: v for k, v in d.items() if v is not None}
 
 
 @argh.arg('--cluster',
@@ -124,20 +124,20 @@ def run_task(**kwargs):
 
     def get_override(container):
         if container.get('name') == kwargs['CMD_CONTAINER']:
-            return filter({
+            return dict(filter({
                 'name': container.get('name'),
                 'command': kwargs['COMMAND'],
                 'cpu': kwargs['CMD_CONTAINER_CPU'],
                 'memory': kwargs['CMD_CONTAINER_MEMORY_LIMIT'],
                 'memoryReservation': kwargs['CMD_CONTAINER_MEMORY_RESERVATION']
-            })
+            }))
         else:
-            return filter({
+            return dict(filter({
                 'name': container.get('name'),
                 'cpu': kwargs['OTHER_CONTAINER_CPU'],
                 'memory': kwargs['OTHER_CONTAINER_MEMORY_LIMIT'],
                 'memoryReservation': kwargs['OTHER_CONTAINER_MEMORY_RESERVATION']
-            })
+            }))
 
     taskdef = client.describe_task_definition(
         taskDefinition=kwargs['ECS_TASK_DEF']
@@ -164,10 +164,12 @@ def run_task(**kwargs):
                 '[ERROR] Only able to stream logs from containers using the awslogs log driver.')
             exit(-1)
 
-    overrides = map(
+    overrides = list(map(
         get_override,
         containers
-    )
+    ))
+
+    
 
     result = client.run_task(
         cluster=kwargs['ECS_CLUSTER'],


### PR DESCRIPTION
AWS API Now expects ContainerOverrides to be a list of dicts, not a list of lists. Fixes the following issue:

```
python ecs-run-cmd --cluster webhop-nioxin-int --task-definition nioxin-api-nioxin-int --region eu-central-1 --count 1 --wait --logs --quiet --cmd-container phpfpm --cmd-container-cpu 0 --cmd-container-memory-reservation 0 --other-container-cpu 0 --other-container-memory-reservation 0 --started-by nioxin-api-nioxin-int/96 -- bash -xc "cd /var/www && composer install --no-interaction --no-ansi && bin/console --env=prod cache:clear && bin/console --env=prod cache:warmup && find \"var/*\" -maxdepth 1  -not -iname \"*PRIVATE*\" -not -iname \"*.sql\" -exec chown -R www-data:www-data {} \;"

Traceback (most recent call last):
  File "ecs-run-cmd", line 222, in <module>
    argh.dispatch_command(run_task)
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/argh/dispatching.py", line 306, in dispatch_command
    dispatch(parser, *args, **kwargs)
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/argh/dispatching.py", line 174, in dispatch
    for line in lines:
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/argh/dispatching.py", line 277, in _execute_command
    for line in result:
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/argh/dispatching.py", line 260, in _call
    result = function(*positional, **keywords)
  File "ecs-run-cmd", line 181, in run_task
    startedBy=kwargs['TASK_STARTED_BY']
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/botocore/client.py", line 649, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/botocore/client.py", line 697, in _convert_to_request_dict
    api_params, operation_model)
  File "/Users/neil/.virtualenvs/python37/lib/python3.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter overrides.containerOverrides[0], value: ['name', 'cpu', 'memoryReservation'], type: <class 'list'>, valid types: <class 'dict'>
Invalid type for parameter overrides.containerOverrides[1], value: ['name', 'command', 'cpu', 'memoryReservation'], type: <class 'list'>, valid types: <class 'dict'>
```

